### PR TITLE
refatorando projectCard para deixar mais modular

### DIFF
--- a/frontend/src/components/Icon/Icon.tsx
+++ b/frontend/src/components/Icon/Icon.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import { SVGType } from 'src/types'
 
-type SVGType = React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+
+// type SVGType = React.FunctionComponent<React.SVGAttributes<SVGElement>>;
 
 // Props do icone - Passar imagem e alt text como parametero. Style eh opcional.
 interface IconProps {

--- a/frontend/src/components/ProjectCard/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard/ProjectCard.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Icon from "../Icon/Icon";
 
 /*
@@ -7,31 +6,35 @@ import Icon from "../Icon/Icon";
 */
 import { GithubDarkIcon } from 'src/assets';
 
-type SVGType = React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+import { ProjectCardProps } from "src/types";
 
-interface ProjectCardProps {
-    title: string;
-    text: string;
-    icons?: React.ElementType[],
-}
 
-function ProjectCard({title, text, icons}: ProjectCardProps){
+function ProjectCard(cardProps: ProjectCardProps){
+    /*
+    atributos disponivoes em cardprops:
+        title : string,
+        content : string,
+        icons?: React.FC[] | SVGType[],
+        iconLinks?: string[]
+    */
+
     return (
         <div className="bg-grayBackground rounded-xl  flex  flex-col md:flex-row px-6 py-5 gap-4 md:justify-between">
 
             <div className="flex flex-col gap-1 md:justify-between md:gap-3 w-5/4">
                 
                 <div className="flex flex-col md:flex-row gap-2 md:items-center">
-                    <h2 className="font-monteserrat font-semibold text-white text-4xl px-2 md:px-0 mr-4">{title}</h2>
+                    <h2 className="font-monteserrat font-semibold text-white text-4xl px-2 md:px-0 mr-4">{cardProps.title}</h2>
                     <div className="flex gap-4">
                         {/* icones */}
-                        {icons?.map((icon) => {
-                            return <Icon style="w-8 select-none" Image={icon as SVGType} alt="tech icon"/>
+                        {cardProps.icons?.map((icon) => {
+                            // TODO : adicionar links para os respectivos icones
+                            return <Icon style="w-8 select-none" Image={icon} alt="tech icon"/>
                         })}
                     </div>
                 </div>
 
-                <p className="font-poppins text-white text-sm w-full px-2 md:px-0 md:w-4/5 text-justify">{text}</p>
+                <p className="font-poppins text-white text-sm w-full px-2 md:px-0 md:w-4/5 text-justify">{cardProps.content}</p>
             </div>
 
             <div>

--- a/frontend/src/pages/Projects/Projects.tsx
+++ b/frontend/src/pages/Projects/Projects.tsx
@@ -1,12 +1,24 @@
 import { ProjectCard } from 'src/components'
 
 import { GithubDarkIcon, InstagramIcon } from 'src/assets'
+import { ProjectCardProps } from 'src/types'
+
+// exemplo de dados que serao retirados do banco de dados e transformados em ProjectCardProps
+const FirstProject : ProjectCardProps = {
+  title : "Projeto 1",
+  content : "Exemplo de projeto muito legal",
+  icons : [GithubDarkIcon, InstagramIcon],
+  iconLinks : ["github.com", "instagram.com"]
+}
 
 function Projects() {
   return (
     <div>
       <div>Projects</div>
-      <ProjectCard title="Projeto 1" text="Exemplo de projeto muito legal" icons={[GithubDarkIcon, InstagramIcon]} />
+      {/* <ProjectCard title="Projeto 1" content="Exemplo de projeto muito legal" icons={[GithubDarkIcon, InstagramIcon]} /> */}
+      
+      {/* obs: chamar para cada projeto, o componente desta forma (evita refatoraçao de codigo): */}
+      <ProjectCard {...FirstProject}/> 
     </div>
   )
 }

--- a/frontend/src/types/PageProps.ts
+++ b/frontend/src/types/PageProps.ts
@@ -1,3 +1,4 @@
+import { SVGType } from "./Types";
 
 /* Interface para props com parametros e children 
 uso:
@@ -10,4 +11,12 @@ export interface UniversalChldrenPageProps extends React.HTMLProps<HTMLDivElemen
 
 export interface UniversalPageProps { // template para definir props **sem children**
     // definir as props aqui
+}
+
+// propr que define um card de projeto para a pagina de projetos
+export interface ProjectCardProps {
+    title : string,
+    content : string,
+    icons?: React.FC[] | SVGType[],
+    iconLinks?: string[]
 }

--- a/frontend/src/types/Types.ts
+++ b/frontend/src/types/Types.ts
@@ -1,0 +1,2 @@
+// define o tipo SVGType para facilitar escrita
+export type SVGType = React.FunctionComponent<React.SVGAttributes<SVGElement>>;

--- a/frontend/src/types/detelethis.txt
+++ b/frontend/src/types/detelethis.txt
@@ -1,1 +1,0 @@
-apague depois que ja houver outra coisa nessa pasta

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,5 @@
+// typing
+export * from './Types';
+
+// props
+export * from './PageProps';


### PR DESCRIPTION
Fiz algumas mudanças no código do card de projeto pensando mais em refatoração de código e modularização

Primeiro, deixei as `tipagens` e as `props` que mais de um código usa no diretório `src/types`. Assim, mais códigos podem acessá-los sem ter que redefini-los todas as vezes.

Alem disso, alterei levemente as props do componente `ProjectCard` para que seja possível o seguinte fluxo:

### Definilção do tipo de dado para cada projeto

Pensando em recuperar dados de banco de dados, deixei a tipagem de `PojectCardProps` uma só na seção de tipagem, e podemos definir um projeto assim:

```typescript
  const MyProjectPropst : ProjectCardProps = {
  title : "Projeto 1",
  content : "Exemplo de projeto muito legal",
  icons : [GithubDarkIcon, InstagramIcon],
  iconLinks : ["github.com", "instagram.com"]
}
```

Dessa forma, ao chamarmos o componente `ProjectCard`, basta fazermos:

```typescript
   <ProjectCard {...MyProjectPropst}/> 
```

Assim, caso seja necessário refatoração no futuro (muito provável), só será necessário mexer em um único local.